### PR TITLE
Make #on: method work properly with toolbar.

### DIFF
--- a/src/Icetray/ITBasicPresenter.class.st
+++ b/src/Icetray/ITBasicPresenter.class.st
@@ -31,6 +31,16 @@ ITBasicPresenter class >> new [
 	^ self owner: nil
 ]
 
+{ #category : #'instance creation' }
+ITBasicPresenter class >> on: aDomainObject [
+	| decorator |
+	decorator := self basicNewWithOwner: nil.
+	decorator decoree
+		setModelBeforeInitialization: aDomainObject;
+		initialize.	
+	^ decorator
+]
+
 { #category : #specs }
 ITBasicPresenter class >> owner: anOwningPresenter [
 


### PR DESCRIPTION
Make #on: method work properly with toolbar.Without this method, when trying to use the toolbar, owner is nil.This code is normally call when sending #new but not when you use #on to specify your model.